### PR TITLE
Match server state with initial state type

### DIFF
--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
 import { getAuth } from 'h3-clerk'
-// import { clerkClient } from '@clerk/clerk-sdk-node'
+import { stripPrivateDataFromObject } from '@clerk/backend/internal';
 
 export function requireClerkSession(event: H3Event) {
   const auth = getAuth(event)
@@ -8,7 +8,7 @@ export function requireClerkSession(event: H3Event) {
   if (!auth.userId)
     throw new Error('No session found')
 
-  return auth
+  return stripPrivateDataFromObject(auth)
 }
 
 export function getClerkSession(event: H3Event) {
@@ -21,5 +21,5 @@ export function getClerkSession(event: H3Event) {
     return null
   }
 
-  return auth
+  return stripPrivateDataFromObject(auth)
 }


### PR DESCRIPTION
By default, the `auth` object returned by the Clerk Node SDK does not match the [`InitialState`](https://github.com/wobsoriano/vue-clerk/blob/1c43814b0e1408a858ef70ff4e09ed99c9608073/src/utils/deriveState.ts#L10) type from the `derivedState` function. Turns out, the Next.js SDK strips out private data objects [here](https://github.com/clerk/javascript/blob/7ec5b1c3ac542ba24225800153e3e1d8f133ea4e/packages/gatsby-plugin-clerk/src/ssr/withServerAuth.ts#L43) and matches the `InitialState` type.